### PR TITLE
Fix: Syntax Error raised when filtering nodes containing single quotes in locator

### DIFF
--- a/BrowserPOM/__init__.py
+++ b/BrowserPOM/__init__.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from Browser import Browser
 from Browser.utils import ScreenshotFileTypes, ScreenshotReturnType
-from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from robot.api.deco import keyword
+from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 
 from .pageobject import PageObject
 from .uiobject import UIObject
@@ -119,11 +119,19 @@ class BrowserPOM(Browser):
         super().__init__(jsextension=str(addon_path))
 
     @keyword
-    def take_screenshot(self, *args, **kwargs):
+    def take_screenshot(self, *args, **kwargs):  # noqa:ANN002,ANN003,ANN201
+        """Take a screenshot, and additionally attach it to the Allure report if
+        the Allure listener is installed.
+        """
         path = self._browser_control.take_screenshot(*args, **kwargs)
         try:
-            import allure
-            allure.attach.file(path, name="screenshot", attachment_type=allure.attachment_type.PNG)
+            import allure  # noqa:PLC0415
+
+            allure.attach.file(
+                path,
+                name="screenshot",
+                attachment_type=allure.attachment_type.PNG,
+            )
         except ImportError:
             pass
         return path

--- a/BrowserPOM/pageobject.py
+++ b/BrowserPOM/pageobject.py
@@ -3,7 +3,7 @@
 import contextlib
 from urllib.parse import urlparse
 
-import robot.api
+import robot.api.logger
 from Browser import Browser
 from robot.api.deco import keyword
 from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError

--- a/BrowserPOM/pom_stubs.py
+++ b/BrowserPOM/pom_stubs.py
@@ -1,8 +1,13 @@
+"""Helper script that can be passed as variable file to robotcode LSP.
+It creates placeholders for the PageObjects, so that robotcode does not
+complain about unknown variables.
+"""
+
 import ast
 from pathlib import Path
 
 
-def get_variables(base_path: str):
+def get_variables(base_path: str) -> dict[str, str]:
     """Return a mapping of class-name -> dummy for classes that inherit PageObject.
 
     Scans Python modules under ``base_path`` and parses their AST. Only classes
@@ -18,26 +23,25 @@ def get_variables(base_path: str):
         """
 
         def _is_pageobject_node(node: ast.AST | None) -> bool:
-            """
-            Recursively check if a node or its relevant child refers
+            """Recursively check if a node or its relevant child refers
             to 'PageObject'.
             """
             if node is None:
                 return False
-            
-            # case: PageObject
+
+            # case PageObject
             if isinstance(node, ast.Name):
                 return node.id == "PageObject"
-            
-            # case: some_module.PageObject
+
+            # case some_module.PageObject
             if isinstance(node, ast.Attribute):
                 return getattr(node, "attr", None) == "PageObject"
-            
-            # case: PageObject[T]
+
+            # case PageObject[T]
             if isinstance(node, ast.Subscript):
                 return _is_pageobject_node(getattr(node, "value", None))
-            
-            # case: PageObject(metaclass=...)
+
+            # case PageObject(metaclass=...)
             if isinstance(node, ast.Call):
                 return _is_pageobject_node(getattr(node, "func", None))
 
@@ -52,13 +56,9 @@ def get_variables(base_path: str):
         try:
             tree = ast.parse(module.read_text("utf8"))
             variables.update(
-                {
-                    node.name: node.name
-                    for node in ast.walk(tree)
-                    if isinstance(node, ast.ClassDef) and _inherits_pageobject(node)
-                }
+                {node.name: node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and _inherits_pageobject(node)},
             )
-        except Exception:
+        except Exception:  # noqa: S112,BLE001
             # ignore parse errors or unreadable files
             continue
 

--- a/BrowserPOM/uiobject.py
+++ b/BrowserPOM/uiobject.py
@@ -70,7 +70,11 @@ class UIObject:
             UIObject: A new UIObject instance representing the filtered object.
 
         """
-        locator = BuiltIn().run_keyword("Playwright Page Method", "locator('" + str(self) + "').filter({" + filter_text + "})")
+        base_locator = str(self).replace("'", '"')
+        locator = BuiltIn().run_keyword(
+            "Playwright Page Method",
+            "locator('" + base_locator + "').filter({" + filter_text + "})",
+        )
         return self.__class__(locator)
 
     def self_locator(self) -> str:

--- a/demo/variables.py
+++ b/demo/variables.py
@@ -1,1 +1,3 @@
-import MainPage
+"""Dummy imports to suppress errors about unknown variables in IDE."""
+
+from . import MainPage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ test = [
     "ruff>=0.11.0,<0.12",
 ]
 dev = [
+    "allure-robotframework>=2.15.3",
     "hatchling",
     "setuptools>=80.9.0,<81",
 ]

--- a/tests/functional/filtering/POM.py
+++ b/tests/functional/filtering/POM.py
@@ -1,0 +1,14 @@
+# ruff:noqa
+from BrowserPOM import PageObject, UIObject
+
+
+class ListItem(UIObject):
+    def __init__(self, locator: str, parent: UIObject | None = None) -> None:
+        super().__init__(locator, parent)
+
+
+class POM(PageObject):
+    # variant 1: uses single quotes inside xPath
+    electronics = ListItem("//li[@data-category='electronics']")
+    # variant 2: uses double quotes inside xPath
+    books = ListItem('//li[@data-category="books"]')

--- a/tests/functional/filtering/filtering.html
+++ b/tests/functional/filtering/filtering.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Page for Element Filtering</title>
+</head>
+<body>
+    <ul>
+        <li id="item-1" data-category="electronics">
+            <div>Laptop</div>
+        </li>
+        <li id="item-2" data-category="books">
+            <div>Python Programming Guide</div>
+        </li>
+        <li id="item-3" data-category="electronics">
+            <div>Mouse</div>
+        </li>
+        <li id="item-4" data-category="books">
+            <div>Robot Framework User Guide</div>
+        </li>
+    </ul>
+</body>
+</html>

--- a/tests/functional/filtering/filtering.robot
+++ b/tests/functional/filtering/filtering.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Documentation       Bug retest: locators containing single quotes led to "Syntax Error" when trying to filter for text,
+...                 for example `${POM.electronics["Laptop"]}`
+
+Library             BrowserPOM
+Library             ./POM.py
+
+Test Setup          New Page    file:///${CURDIR}/filtering.html
+
+
+*** Test Cases ***
+Filtering by index
+    Get Attribute    ${POM.electronics[0]}    id    equals    item-1
+    Get Attribute    ${POM.electronics[1]}    id    equals    item-3
+
+Filtering by text content
+    Get Attribute    ${POM.electronics["Laptop"]}    id    equals    item-1
+    Get Attribute    ${POM.books["Python Programming Guide"]}    id    equals    item-2

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,46 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "allure-python-commons"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/93/609cf76e204567cb618b59208f34468bbd434f34fcdce3d193d8f927abcd/allure_python_commons-2.15.3.tar.gz", hash = "sha256:b42a96d6076fb323c9e43645dfb84c0574f6bad0a0e005d92564015cd172d564", size = 15208, upload-time = "2025-12-30T05:21:46.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/2e/a823ab87aa8ed064d7efc817d79eb5f013465514f8d74487f1519849049f/allure_python_commons-2.15.3-py3-none-any.whl", hash = "sha256:50e9b346d8a060c84af8d19f221bd9da6e1aa0002a4e7f770e151167365219d0", size = 16212, upload-time = "2025-12-30T05:21:45.861Z" },
+]
+
+[[package]]
+name = "allure-robotframework"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "allure-python-commons" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/68/c9f4ad892131bdeac9b092cf1c2fa18277e0dc4cf17636b16c198d37679d/allure_robotframework-2.15.3.tar.gz", hash = "sha256:a9c17e3ef2c46d3025c2e3579a87d7a03664561e2305ee03808682900f5e374d", size = 13095, upload-time = "2025-12-30T05:22:02.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/67/b9b1a184b088c15b33886b80549ac0e7e7555c6a339b40c6c33b2b3a9ba7/allure_robotframework-2.15.3-py3-none-any.whl", hash = "sha256:5d828d8ee9cf684f407310a504717accacfd715babcdff794d61995e68138e7c", size = 9333, upload-time = "2025-12-30T05:22:01.172Z" },
+]
+
+[[package]]
 name = "ansi2html"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/d5/e3546dcd5e4a9566f4ed8708df5853e83ca627461a5b048a861c6f8e7a26/ansi2html-1.9.2.tar.gz", hash = "sha256:3453bf87535d37b827b05245faaa756dbab4ec3d69925e352b6319c3c955c0a5", size = 44300, upload-time = "2024-06-22T17:33:23.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/71/aee71b836e9ee2741d5694b80d74bfc7c8cd5dbdf7a9f3035fcf80d792b1/ansi2html-1.9.2-py3-none-any.whl", hash = "sha256:dccb75aa95fb018e5d299be2b45f802952377abfdce0504c17a6ee6ef0a420c5", size = 17614, upload-time = "2024-06-22T17:33:21.852Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -598,6 +632,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "allure-robotframework" },
     { name = "hatchling" },
     { name = "setuptools" },
 ]
@@ -617,6 +652,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "allure-robotframework", specifier = ">=2.15.3" },
     { name = "hatchling" },
     { name = "setuptools", specifier = ">=80.9.0,<81" },
 ]


### PR DESCRIPTION
Problem description:

When using the `${PageObject.my_object["textToFilter"]}` syntax, the constructed JavaScript code that is evaluated in `playwrightPageMethod` contained a SyntaxError if one of the locators includes single quotes.

Ad-hoc solution: 

Replace single quotes in locator with double quotes before constructing the JS code to evaluate.

This will still lead to problems if the xPath must contain both kinds of quotes, but it's still an improvement to the current implementation.

Notes:

* First commit contains few necessary changes to get `prek` to pass. I assume `demo/variables.py` could also be removed as it's not used anymore.
* The included test file and structure is a proposal how more focused tests for individual functionality could be set up, which require more control over the actual HTML content to test against. Up for debate if this is a direction you would like to go. The initial idea was to create one folder for each test/feature, containing minimal HTML, Python files and Robot scripts.