### PR TITLE
docs: run docs job only in own repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,6 +39,7 @@ jobs:
 
   publish-docs:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
Currently the `publish-docs` job is started for every pull request targeting the master branch.
For PRs originating from a fork, it fails because the workflow runs with reduced permissions.

The proposed change would be the minimally invasive solution if you want to keep the single GitHub Actions workflow file. Splitting into distinct files would be an alternative to have more control by configuring different triggers in the `on:` section.